### PR TITLE
Aws redshift proxy

### DIFF
--- a/cmd/proxy_client.go
+++ b/cmd/proxy_client.go
@@ -42,11 +42,17 @@ var proxyClientCommand = &cobra.Command{
 		if err != nil {
 			return err
 		}
+
+		redshiftClient, err := aws.NewRedshiftClient(ctx)
+		if err != nil {
+			return err
+		}
+
 		filepath, err := cmd.Flags().GetString("configfile")
 		if err != nil {
 			return err
 		}
-		cfg, err := config.LoadConfig(ctx, rdsClient, filepath)
+		cfg, err := config.LoadConfig(ctx, rdsClient, redshiftClient, filepath)
 		if err != nil {
 			return err
 		}
@@ -58,7 +64,7 @@ var proxyClientCommand = &cobra.Command{
 		}
 
 		// Look up the real target name in the target list
-		target, err := getTarget(cmd, cfg.Targets, cfg.RDSTargets)
+		target, err := getTarget(cmd, cfg.Targets, cfg.RDSTargets, cfg.RedshiftTargets)
 		if err != nil {
 			return err
 		}
@@ -141,6 +147,13 @@ var proxyClientCommand = &cobra.Command{
 						return err
 					}
 					creds.Password = authToken
+				} else if _, ok := cfg.RedshiftTargets[target.Name]; ok {
+					authToken, err := redshiftClient.NewAuthToken(ctx, target.Name, target.Region, creds.Username)
+					if err != nil {
+						return err
+					}
+					creds.Username = "IAM:" + creds.Username
+					creds.Password = authToken
 				}
 
 				if !proxyTarget.AwsAuthOnly {
@@ -215,7 +228,7 @@ func getProxyTarget(cmd *cobra.Command, targets map[string]*config.ProxyTarget) 
 	return nil, fmt.Errorf("couldn't find a proxy target")
 }
 
-func getTarget(cmd *cobra.Command, targets map[string]*config.Target, rdsTargets map[string]*config.Target) (*config.Target, error) {
+func getTarget(cmd *cobra.Command, targets map[string]*config.Target, rdsTargets map[string]*config.Target, redshiftTargets map[string]*config.Target) (*config.Target, error) {
 	// Look up the proxy target
 	targetName, err := cmd.Flags().GetString("target")
 	if err != nil {
@@ -232,11 +245,19 @@ func getTarget(cmd *cobra.Command, targets map[string]*config.Target, rdsTargets
 		return target, nil
 	}
 
+	target, ok = redshiftTargets[targetName]
+	if ok {
+		return target, nil
+	}
+
 	opts := make([]string, 0, len(targets)+len(rdsTargets))
 	for name := range targets {
 		opts = append(opts, name)
 	}
 	for name := range rdsTargets {
+		opts = append(opts, name)
+	}
+	for name := range redshiftTargets {
 		opts = append(opts, name)
 	}
 
@@ -259,6 +280,12 @@ func getTarget(cmd *cobra.Command, targets map[string]*config.Target, rdsTargets
 	if ok {
 		return target, nil
 	}
+
+	target, ok = redshiftTargets[targetName]
+	if ok {
+		return target, nil
+	}
+
 	return nil, fmt.Errorf("couldn't find a target db")
 }
 

--- a/cmd/proxy_client.go
+++ b/cmd/proxy_client.go
@@ -117,16 +117,21 @@ var proxyClientCommand = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		var outboundHost string
+
+		if proxyTarget.AwsAuthOnly {
+			outboundHost = target.Host
+		} else {
+			outboundHost = proxyTarget.GetHost()
+		}
 
 		manager, err := proxy.NewManager(proxy.MergeOptions(opts, []proxy.Option{
 			proxy.WithListenAddress(cfg.Proxy.ListenAddr),
 			proxy.WithMode(proxy.ClientSide),
+			proxy.WithAWSAuthOnly(proxyTarget.AwsAuthOnly),
 			proxy.WithCredentialInterceptor(func(creds *proxy.Credentials) error {
 				// Send this connection to the proxy host
-				creds.Host = proxyTarget.GetHost()
-				// But tell the server proxy to forward to the target host
-				creds.Options["host"] = target.Host
-
+				creds.Host =  outboundHost
 				// Use provided password, or generate an RDS password to forward through
 				if pass != "" {
 					creds.Password = pass
@@ -136,6 +141,10 @@ var proxyClientCommand = &cobra.Command{
 						return err
 					}
 					creds.Password = authToken
+				}
+
+				if !proxyTarget.AwsAuthOnly {
+					creds.Options["host"] = target.Host
 				}
 
 				return overrideSSLConfig(creds, proxyTarget.SSL)

--- a/cmd/proxy_server.go
+++ b/cmd/proxy_server.go
@@ -31,7 +31,11 @@ var proxyServerCommand = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		cfg, err := config.LoadConfig(ctx, rdsClient, filepath)
+		redshiftClient, err := aws.NewRedshiftClient(ctx)
+		if err != nil {
+			return err
+		}
+		cfg, err := config.LoadConfig(ctx, rdsClient, redshiftClient, filepath)
 		if err != nil {
 			return err
 		}
@@ -56,7 +60,7 @@ var proxyServerCommand = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		config.RefreshTargets(ctx, &cfg, rdsClient, 1*time.Minute)
+		config.RefreshTargets(ctx, &cfg, rdsClient, redshiftClient, 1*time.Minute)
 		err = manager.Start(ctx)
 		return err
 	},

--- a/configs/rds_auth_only_config.yaml
+++ b/configs/rds_auth_only_config.yaml
@@ -1,0 +1,40 @@
+proxy:
+  # The listen addr of this proxy
+  listen_addr: 127.0.0.1:5433
+  ##
+  # SSL Config
+  #
+  # The SSL config for the proxy itself. SSL for individual 
+  # hosts/targets is defined below
+  ssl:
+    enabled: false 
+  
+  ##
+  # Target ACL
+  #
+  # Configure allowed or blocked hosts / RDS instances.
+  target_acl:
+    allowed_rds_tags: []
+    blocked_rds_tags: []
+
+##
+# Upstream Proxies Configuration
+#
+# This is where you can specify upstream proxy settings
+upstream_proxies:
+  default: 
+    host: rds-proxy-server:8000
+    ssl:
+      mode: "require"
+    aws_auth_only: true
+
+## 
+# Target configuration
+#
+# This is where you can specify SSL settings for the upstream
+# (non-RDS) databases 
+#
+# RDS databases are added automatically at runtime.
+targets:
+  postgres:
+    host: postgres:5432

--- a/go.mod
+++ b/go.mod
@@ -4,10 +4,11 @@ go 1.14
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.2
-	github.com/aws/aws-sdk-go-v2 v1.9.1
+	github.com/aws/aws-sdk-go-v2 v1.11.2
 	github.com/aws/aws-sdk-go-v2/config v1.8.2
 	github.com/aws/aws-sdk-go-v2/feature/rds/auth v1.1.7
 	github.com/aws/aws-sdk-go-v2/service/rds v1.9.0
+	github.com/aws/aws-sdk-go-v2/service/redshift v1.17.0
 	github.com/imdario/mergo v0.3.8 // indirect
 	github.com/jackc/pgproto3/v2 v2.1.1
 	github.com/spf13/afero v1.6.0

--- a/pkg/aws/redshift.go
+++ b/pkg/aws/redshift.go
@@ -1,0 +1,85 @@
+package aws
+
+import (
+	"context"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/redshift"
+	"github.com/aws/aws-sdk-go-v2/service/redshift/types"
+)
+
+// RedshiftClusterResult is wrapper around a DBInstance or error
+// as a result of listing Redshift cluster
+type RedshiftClusterResult struct {
+	Instance types.Cluster
+	Error    error
+}
+
+// RedshiftClient is our wrapper around the Redshift library, allows us to
+// mock this for testing
+type RedshiftClient interface {
+	GetRedshiftInstances(ctx context.Context) <-chan RedshiftClusterResult
+	NewAuthToken(ctx context.Context, clusterId, region, user string) (string, error)
+	RegionForInstance(inst types.Cluster) (string, error)
+}
+
+type redshiftClient struct {
+	cfg aws.Config
+	svc *redshift.Client
+}
+
+// NewRedshiftClient loads AWS Config and creds, and returns an Redshift client
+func NewRedshiftClient(ctx context.Context) (*redshiftClient, error) {
+	cfg, err := config.LoadDefaultConfig(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &redshiftClient{cfg: cfg, svc: redshift.NewFromConfig(cfg)}, nil
+}
+
+// GetPostgresInstances grabs all db instances filtered by engine "postgres" and publishes
+// them to the result channel
+func (r *redshiftClient) GetRedshiftInstances(ctx context.Context) <-chan RedshiftClusterResult {
+	resChan := make(chan RedshiftClusterResult, 1)
+	go func() {
+		defer close(resChan)
+		paginator := r.redshiftPaginator()
+		for paginator.HasMorePages() {
+			page, err := paginator.NextPage(ctx)
+			if err != nil {
+				resChan <- RedshiftClusterResult{Error: err}
+				return
+			}
+			for _, d := range page.Clusters {
+				resChan <- RedshiftClusterResult{Instance: d}
+			}
+		}
+	}()
+	return resChan
+}
+
+func (r *redshiftClient) redshiftPaginator() (paginator *redshift.DescribeClustersPaginator) {
+	paginator = redshift.NewDescribeClustersPaginator(r.svc, &redshift.DescribeClustersInput{}, func(o *redshift.DescribeClustersPaginatorOptions) {
+		o.Limit = 100
+	})
+	return
+}
+
+func (r *redshiftClient) NewAuthToken(ctx context.Context, clusterId, region, user string) (string, error) {
+	credentials, err := r.svc.GetClusterCredentials(ctx, &redshift.GetClusterCredentialsInput{
+		AutoCreate: aws.Bool(false),
+		ClusterIdentifier: strPtr(clusterId),
+		DbUser: strPtr(user),
+	})
+
+	return *credentials.DbPassword, err
+}
+
+func (r *redshiftClient) RegionForInstance(inst types.Cluster) (string, error) {
+	arn, err := arn.Parse(*inst.ClusterNamespaceArn)
+	if err != nil {
+		return "", err
+	}
+	return arn.Region, nil
+}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -28,7 +28,7 @@ func TestProxyConfigLoad(t *testing.T) {
 		},
 	}
 	for idx, test := range cases {
-		pcfg, err := LoadConfig(context.Background(), &mockRDSClient{}, test.FileName)
+		pcfg, err := LoadConfig(context.Background(), &mockRDSClient{}, &mockRedshiftClient{}, test.FileName)
 		if !errorContains(err, test.Error) {
 			t.Errorf("[Case %d] expected %+v, got %+v", idx, test.Error, err)
 		}

--- a/pkg/config/redshift.go
+++ b/pkg/config/redshift.go
@@ -1,0 +1,71 @@
+package config
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/mothership/rds-auth-proxy/pkg/aws"
+	"github.com/mothership/rds-auth-proxy/pkg/log"
+	"github.com/mothership/rds-auth-proxy/pkg/pg"
+	"go.uber.org/zap"
+)
+
+const (
+	redshiftDefaultDatabaseTag = "rds-auth-proxy:db-name"
+	redshiftLocalPortTag       = "rds-auth-proxy:local-port"
+)
+
+// RefreshRedshiftTargets searches AWS for allowed dbs updates the target list
+func RefreshRedshiftTargets(ctx context.Context, cfg *ConfigFile, redshiftClient aws.RedshiftClient) (err error) {
+	// XXX: Must consume ALL of these, else I think we leak the channel
+	resChan := redshiftClient.GetRedshiftInstances(ctx)
+	redshiftTargets := map[string]*Target{}
+	for result := range resChan {
+		if result.Error != nil {
+			err = result.Error
+			continue
+		}
+		d := result.Instance
+		if d.Endpoint == nil {
+			log.Warn("db instance missing endpoint, skipping", zap.String("name", *d.ClusterIdentifier))
+			continue
+		}
+
+		//TODO: refactor to support redshift ACL filter
+		//if tmpErr := cfg.Proxy.ACL.IsAllowed(d.Tags); tmpErr != nil {
+		//	log.Debug("redshift not allowed by acl", zap.String("name", *d.ClusterIdentifier))
+		//	continue
+		//}
+
+		region, err := redshiftClient.RegionForInstance(d)
+		if err != nil {
+			log.Error("failed to detect redshift region, skipping", zap.Error(err), zap.String("name", *d.ClusterIdentifier))
+			continue
+		}
+
+		target := &Target{
+			Name:            *d.ClusterIdentifier,
+			Host:            fmt.Sprintf("%+v:%+v", *d.Endpoint.Address, strconv.FormatInt(int64(d.Endpoint.Port), 10)),
+			DefaultDatabase: d.DBName,
+			SSL: SSL{
+				Mode:                  pg.SSLVerifyFull,
+				ClientCertificatePath: cfg.Proxy.SSL.ClientCertificatePath,
+				ClientPrivateKeyPath:  cfg.Proxy.SSL.ClientPrivateKeyPath,
+			},
+			Region: region,
+		}
+
+		for _, tag := range d.Tags {
+			if *tag.Key == redshiftDefaultDatabaseTag {
+				target.DefaultDatabase = tag.Value
+			} else if *tag.Key == redshiftLocalPortTag {
+				target.LocalPort = tag.Value
+			}
+		}
+		redshiftTargets[target.Name] = target
+	}
+	cfg.RedshiftTargets = redshiftTargets
+	cfg.RefreshHostMap()
+	return err
+}

--- a/pkg/config/redshift_test.go
+++ b/pkg/config/redshift_test.go
@@ -1,0 +1,35 @@
+package config_test
+
+import (
+	"context"
+	"github.com/aws/aws-sdk-go-v2/service/redshift/types"
+	"github.com/mothership/rds-auth-proxy/pkg/aws"
+)
+
+type mockRedshiftClient struct {
+	Return []aws.RedshiftClusterResult
+}
+
+var _ aws.RedshiftClient = (*mockRedshiftClient)(nil)
+
+func (m *mockRedshiftClient) GetRedshiftInstances(ctx context.Context) <-chan aws.RedshiftClusterResult {
+	retChan := make(chan aws.RedshiftClusterResult, 1)
+	go func() {
+		defer close(retChan)
+		for _, r := range m.Return {
+			retChan <- r
+			if r.Error != nil {
+				return
+			}
+		}
+	}()
+	return retChan
+}
+
+func (m *mockRedshiftClient) NewAuthToken(ctx context.Context, clusterId, region, user string) (string, error) {
+	return "", nil
+}
+
+func (m *mockRedshiftClient) RegionForInstance(d types.Cluster) (string, error) {
+	return "us-west-2", nil
+}

--- a/pkg/config/refresh.go
+++ b/pkg/config/refresh.go
@@ -10,7 +10,7 @@ import (
 )
 
 // RefreshTargets refreshes the proxy target list on an interval
-func RefreshTargets(ctx context.Context, cfg *ConfigFile, rdsClient aws.RDSClient, period time.Duration) {
+func RefreshTargets(ctx context.Context, cfg *ConfigFile, rdsClient aws.RDSClient, redshiftClient aws.RedshiftClient, period time.Duration) {
 	go func() {
 		t := time.NewTicker(period)
 		for {
@@ -22,6 +22,9 @@ func RefreshTargets(ctx context.Context, cfg *ConfigFile, rdsClient aws.RDSClien
 				log.Info("starting target refresh", zap.Strings("targets", targetNames(cfg.RDSTargets)))
 				_ = RefreshRDSTargets(ctx, cfg, rdsClient)
 				log.Info("refresh done", zap.Strings("targets", targetNames(cfg.RDSTargets)))
+				log.Info("starting target refresh", zap.Strings("targets", targetNames(cfg.RedshiftTargets)))
+				_ = RefreshRedshiftTargets(ctx, cfg, redshiftClient)
+				log.Info("refresh done", zap.Strings("targets", targetNames(cfg.RedshiftTargets)))
 			}
 		}
 	}()

--- a/pkg/config/targets.go
+++ b/pkg/config/targets.go
@@ -10,6 +10,7 @@ type ProxyTarget struct {
 	// For tunneling the connection through a kubernetes port-forward, only useful
 	// for client-side proxy targets
 	PortForward *PortForward `mapstructure:"port_forward,omitempty"`
+	AwsAuthOnly bool `mapstructure:"aws_auth_only", default:false`
 }
 
 // GetHost returns the correct host + port combo for the proxy target

--- a/pkg/proxy/config.go
+++ b/pkg/proxy/config.go
@@ -47,6 +47,7 @@ type Config struct {
 	CredentialInterceptor    CredentialInterceptor
 	QueryInterceptor         QueryInterceptor
 	Mode                     Mode
+	AwsAuthOnly				 bool `default:false`
 }
 
 // QueryInterceptor provides a way to define custom behavior for handling messages
@@ -78,6 +79,13 @@ func WithListenAddress(addr string) Option {
 		}
 
 		c.ListenAddress = listenAddr
+		return nil
+	}
+}
+
+func WithAWSAuthOnly(aws_auth_only bool) Option {
+	return func(c *Config) error {
+		c.AwsAuthOnly = aws_auth_only
 		return nil
 	}
 }


### PR DESCRIPTION
adds the ability to proxy redshift to the client; depends on aws auth client proxy only