### PR TITLE
docs: fix aws permissions in documentation

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -36,8 +36,7 @@ In order to do this, it must be able to list RDS instances. An example IAM polic
             "rds:ListTagsForResource"
          ],
          "Resource": [
-            "arn:aws:rds:*:*:db:*",
-            "arn:aws:rds:*:*:pg:*"
+            "arn:aws:rds:*:*:db:*"
         ]
       }
    ]


### PR DESCRIPTION
pg stands for parametergroup, this package does not interact with param
groups.