### PR TITLE
feat: update RDS CA bundle

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Lint 
-        uses: golangci/golangci-lint-action@v2
+      - name: Setup Go
+        uses: actions/setup-go@v2.1.3
         with:
-          version: v1.45
+          go-version: 1.17.x
+      - name: Lint 
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.51

--- a/build/bin/import_certs.sh
+++ b/build/bin/import_certs.sh
@@ -2,18 +2,17 @@
 set -e
 
 mydir=/tmp/rds-ca
-if [ ! -e "${mydir}" ]
-then
-mkdir -p "${mydir}"
+if [ ! -e "${mydir}" ]; then
+    mkdir -p "${mydir}"
 fi
 
 pushd "${mydir}"
-curl -sS "https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem" > ${mydir}/rds-combined-ca-bundle.pem
-awk 'split_after == 1 {n++;split_after=0} /-----END CERTIFICATE-----/ {split_after=1}{print > "rds-ca-" n ""}' < ${mydir}/rds-combined-ca-bundle.pem
+curl -sS "https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem" >${mydir}/rds-combined-ca-bundle.pem
+awk 'split_after == 1 {n++;split_after=0} /-----END CERTIFICATE-----/ {split_after=1}{print > "rds-ca-" n ""}' <${mydir}/rds-combined-ca-bundle.pem
 
 for CERT in rds-ca-*; do
-    mv "$CERT" "/usr/local/share/ca-certificates/aws-rds-ca-$(basename $CERT).crt" 
-done 
+    mv "$CERT" "/usr/local/share/ca-certificates/aws-rds-ca-$(basename $CERT).crt"
+done
 
 popd
 rm -rf ${mydir}


### PR DESCRIPTION
Updating to new link for the combined cert bundle from [AWS](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html#UsingWithRDS.SSL.CertificatesAllRegions).